### PR TITLE
Option for cropping layers

### DIFF
--- a/io_import_psd_layers_as_planes.py
+++ b/io_import_psd_layers_as_planes.py
@@ -160,7 +160,7 @@ def create_objects(self, psd_layers, bboxes, image_size, img_dir, psd_name, laye
                 pass
 
     def get_transforms(layer, bbox, i_offset):
-        if self.crop_layers:
+        if self.crop_layers and bbox is not None:
             x = layer.bbox.x1 + bbox[0]
             y = layer.bbox.y1 + bbox[1]
             width = bbox[2] - bbox[0]

--- a/io_import_psd_layers_as_planes.py
+++ b/io_import_psd_layers_as_planes.py
@@ -83,7 +83,7 @@ def parse_psd(self, psd_file):
             suffix = ' - {}'.format(layer.name)
             print_progress(i+1, max=(len(layers)), barlen=40, prefix=prefix, suffix=suffix, line_width=120)
             if self.layer_index_name:
-                name = '_'.join((bpy.path.clean_name(layer.name), str(layer._index)))
+                name = '_'.join((bpy.path.clean_name(layer.name).rstrip('_'), str(layer._index)))
             else:
                 name = bpy.path.clean_name(layer.name).rstrip('_')
             png_file = os.path.join(png_dir, ''.join((name, '.png')))

--- a/io_import_psd_layers_as_planes.py
+++ b/io_import_psd_layers_as_planes.py
@@ -416,7 +416,9 @@ def create_objects(self, psd_layers, bboxes, image_size, img_dir, psd_name, laye
             empty = bpy.data.objects.new(name, None)
             bpy.context.scene.objects.link(empty)
             empty.layers = layers
-            animation_tools_prop = {'import_id': import_id, 'layer_index': layer_index, 'psd_layer_name': psd_layer_name}
+            animation_tools_prop = {'import_id': import_id,
+                                    'layer_index': layer_index,
+                                    'psd_layer_name': psd_layer_name}
             empty['2d_animation_tools'] = animation_tools_prop
             group_object(empty, parent, root_group, group_empty, group_group, import_id)
             groups.append(empty)

--- a/io_import_psd_layers_as_planes.py
+++ b/io_import_psd_layers_as_planes.py
@@ -82,7 +82,10 @@ def parse_psd(self, psd_file):
             prefix = '  - exporting: '
             suffix = ' - {}'.format(layer.name)
             print_progress(i+1, max=(len(layers)), barlen=40, prefix=prefix, suffix=suffix, line_width=120)
-            name = '_'.join((bpy.path.clean_name(layer.name), str(layer._index)))
+            if self.layer_index:
+                name = '_'.join((bpy.path.clean_name(layer.name), str(layer._index)))
+            else:
+                name = bpy.path.clean_name(layer.name)
             png_file = os.path.join(png_dir, ''.join((name, '.png')))
             try:
                 layer_image = layer.as_PIL()
@@ -413,7 +416,10 @@ def create_objects(self, psd_layers, bboxes, image_size, img_dir, psd_name, laye
         else:
             bbox = bboxes[i]
             transforms = get_transforms(layer, bbox, i_offset)
-            filename = '_'.join((name, str(layer._index)))
+            if self.layer_index:
+                filename = '_'.join((name, str(layer._index)))
+            else:
+                filename = name
             img_path = os.path.join(img_dir, ''.join((filename, '.png')))
             plane = create_textured_plane(name, transforms, global_matrix,
                                           import_id, layer_index, psd_layer_name, img_path)
@@ -522,6 +528,10 @@ class ImportPsdAsPlanes(bpy.types.Operator, ImportHelper, IOPSDOrientationHelper
         name='Relative Path',
         description='Select the file relative to the blend file',
         default=True)
+    layer_index = BoolProperty(
+        name='Layer Index',
+        description='Add layer index to the png name. If not, possible conflicts may arise',
+        default=True)
     
     @classmethod
     def poll(self,context):
@@ -581,6 +591,7 @@ class ImportPsdAsPlanes(bpy.types.Operator, ImportHelper, IOPSDOrientationHelper
         col = box.column()
         col.prop(self, 'rel_path')
         col.prop(self, 'hidden_layers', icon='GHOST_ENABLED')
+        col.prop(self, 'layer_index')
 
     def execute(self, context):
         if context.active_object and context.active_object.mode == 'EDIT':

--- a/io_import_psd_layers_as_planes.py
+++ b/io_import_psd_layers_as_planes.py
@@ -155,8 +155,8 @@ def create_objects(self, psd_layers, bboxes, image_size, img_dir, psd_name, laye
         if self.crop_layers:
             x = layer.bbox.x1 + bbox[0]
             y = layer.bbox.y1 + bbox[1]
-            width = layer.bbox.x1 + bbox[2] - (layer.bbox.x1 + bbox[0])
-            height = layer.bbox.y1 + bbox[3] - (layer.bbox.y1 + bbox[1])
+            width = bbox[2] - bbox[0]
+            height = bbox[3] - bbox[1]
         else:
             x = layer.bbox.x1
             y = layer.bbox.y1
@@ -512,7 +512,11 @@ class ImportPsdAsPlanes(bpy.types.Operator, ImportHelper, IOPSDOrientationHelper
         name='Relative Path',
         description='Select the file relative to the blend file',
         default=True)
-
+    
+    @classmethod
+    def poll(self,context):
+        return context.mode == 'OBJECT'
+        
     def draw(self, context):
         layout = self.layout
 

--- a/io_import_psd_layers_as_planes.py
+++ b/io_import_psd_layers_as_planes.py
@@ -223,6 +223,7 @@ def create_objects(self, psd_layers, bboxes, image_size, img_dir, psd_name, laye
         # Texture not found, create a new one
         tex = bpy.data.textures.new(name, 'IMAGE')
         tex.use_mipmap = self.use_mipmap
+        tex.extension = 'CLIP' if self.clip else 'REPEAT'
         tex.image = img
         tex['2d_animation_tools'] = {'import_id': import_id}
         return tex
@@ -484,6 +485,10 @@ class ImportPsdAsPlanes(bpy.types.Operator, ImportHelper, IOPSDOrientationHelper
         name='Size',
         description='The width or height of the image in Blender units',
         default=2)
+    clip = BoolProperty(
+        name='Clip texture',
+        description='Use CLIP as image extension. Avoids fringes on the edges',
+        default=True)
     use_mipmap = BoolProperty(
         name='MIP Map',
         description='Use auto-generated MIP maps for the images. Turning this off leads to sharper rendered images',
@@ -539,7 +544,7 @@ class ImportPsdAsPlanes(bpy.types.Operator, ImportHelper, IOPSDOrientationHelper
         col.separator()
         col.prop(self, 'offset')
         col.separator()
-        col.prop(self, 'crop_layers')
+        col.prop(self, 'crop_layers', toggle=True)
         # Grouping options
         box = layout.box()
         box.label('Grouping', icon='GROUP')
@@ -564,6 +569,7 @@ class ImportPsdAsPlanes(bpy.types.Operator, ImportHelper, IOPSDOrientationHelper
             else:
                 mipmap_icon = 'ALIASED'
             col.prop(self, 'use_mipmap', icon=mipmap_icon, toggle=True)
+            col.prop(self, 'clip', toggle=True)
         # Import options
         box = layout.box()
         box.label('Import options', icon='FILTER')

--- a/io_import_psd_layers_as_planes.py
+++ b/io_import_psd_layers_as_planes.py
@@ -82,10 +82,10 @@ def parse_psd(self, psd_file):
             prefix = '  - exporting: '
             suffix = ' - {}'.format(layer.name)
             print_progress(i+1, max=(len(layers)), barlen=40, prefix=prefix, suffix=suffix, line_width=120)
-            if self.layer_index:
+            if self.layer_index_name:
                 name = '_'.join((bpy.path.clean_name(layer.name), str(layer._index)))
             else:
-                name = bpy.path.clean_name(layer.name)
+                name = bpy.path.clean_name(layer.name).rstrip('_')
             png_file = os.path.join(png_dir, ''.join((name, '.png')))
             try:
                 layer_image = layer.as_PIL()
@@ -137,7 +137,7 @@ def create_objects(self, psd_layers, bboxes, image_size, img_dir, psd_name, laye
     def get_parent(parent, import_id):
         if parent.name == '_RootGroup':
             return root_empty
-        parent_name = bpy.path.clean_name(parent.name)
+        parent_name = bpy.path.clean_name(parent.name).rstrip('_')
         parent_index = str(parent._index)
         for obj in bpy.context.scene.objects:
             if (parent_name in obj.name and obj.type == 'EMPTY' and
@@ -401,6 +401,9 @@ def create_objects(self, psd_layers, bboxes, image_size, img_dir, psd_name, laye
         print_progress(i+1, max=(len(psd_layers)), barlen=40, prefix=prefix, suffix=suffix, line_width=120)
 
         name = bpy.path.clean_name(layer.name)
+        #if not self.layer_index_name:
+        name = name.rstrip('_')
+        
         psd_layer_name = layer.name
         layer_index = str(layer._index)
         parent = layer.parent
@@ -416,10 +419,10 @@ def create_objects(self, psd_layers, bboxes, image_size, img_dir, psd_name, laye
         else:
             bbox = bboxes[i]
             transforms = get_transforms(layer, bbox, i_offset)
-            if self.layer_index:
+            if self.layer_index_name:
                 filename = '_'.join((name, str(layer._index)))
             else:
-                filename = name
+                filename = name.rstrip('_')
             img_path = os.path.join(img_dir, ''.join((filename, '.png')))
             plane = create_textured_plane(name, transforms, global_matrix,
                                           import_id, layer_index, psd_layer_name, img_path)
@@ -528,7 +531,7 @@ class ImportPsdAsPlanes(bpy.types.Operator, ImportHelper, IOPSDOrientationHelper
         name='Relative Path',
         description='Select the file relative to the blend file',
         default=True)
-    layer_index = BoolProperty(
+    layer_index_name = BoolProperty(
         name='Layer Index',
         description='Add layer index to the png name. If not, possible conflicts may arise',
         default=True)
@@ -591,7 +594,7 @@ class ImportPsdAsPlanes(bpy.types.Operator, ImportHelper, IOPSDOrientationHelper
         col = box.column()
         col.prop(self, 'rel_path')
         col.prop(self, 'hidden_layers', icon='GHOST_ENABLED')
-        col.prop(self, 'layer_index')
+        col.prop(self, 'layer_index_name')
 
     def execute(self, context):
         if context.active_object and context.active_object.mode == 'EDIT':

--- a/io_import_psd_layers_as_planes.py
+++ b/io_import_psd_layers_as_planes.py
@@ -76,7 +76,7 @@ def parse_psd(self, psd_file):
         bboxes = []
         for i, layer in enumerate(layers):
             if (isinstance(layer, psd_tools.user_api.psd_image.Group) or
-                    (not layer.visible_global and self.hidden_layers)):
+                    (not self.hidden_layers and not layer.visible_global)):
                 bboxes.append(None)
                 continue
             prefix = '  - exporting: '

--- a/io_import_psd_layers_as_planes.py
+++ b/io_import_psd_layers_as_planes.py
@@ -82,10 +82,9 @@ def parse_psd(self, psd_file):
             prefix = '  - exporting: '
             suffix = ' - {}'.format(layer.name)
             print_progress(i+1, max=(len(layers)), barlen=40, prefix=prefix, suffix=suffix, line_width=120)
+            name = bpy.path.clean_name(layer.name).rstrip('_')
             if self.layer_index_name:
-                name = '_'.join((bpy.path.clean_name(layer.name).rstrip('_'), str(layer._index)))
-            else:
-                name = bpy.path.clean_name(layer.name).rstrip('_')
+                name = name + '_' + str(layer._index)
             png_file = os.path.join(png_dir, ''.join((name, '.png')))
             try:
                 layer_image = layer.as_PIL()
@@ -420,9 +419,7 @@ def create_objects(self, psd_layers, bboxes, image_size, img_dir, psd_name, laye
         suffix = ' - {}'.format(layer.name)
         print_progress(i+1, max=(len(psd_layers)), barlen=40, prefix=prefix, suffix=suffix, line_width=120)
 
-        name = bpy.path.clean_name(layer.name)
-        #if not self.layer_index_name:
-        name = name.rstrip('_')
+        name = bpy.path.clean_name(layer.name).rstrip('_')
 
         psd_layer_name = layer.name
         layer_index = str(layer._index)
@@ -443,9 +440,7 @@ def create_objects(self, psd_layers, bboxes, image_size, img_dir, psd_name, laye
             transforms = get_transforms(layer, bbox, i_offset)
             dimensions = get_dimensions(layer, bbox)
             if self.layer_index_name:
-                filename = '_'.join((name, str(layer._index)))
-            else:
-                filename = name.rstrip('_')
+                filename = name + '_' + str(layer._index)
             img_path = os.path.join(img_dir, ''.join((filename, '.png')))
             plane = create_textured_plane(name, transforms, global_matrix,
                                           import_id, layer_index, psd_layer_name, img_path, self.create_original_uvs, dimensions)


### PR DESCRIPTION
-When using Krita for psd generation (and possibly Photoshop too), some filters or operations leave the layer's canvas larger than the actual pixels, sometimes extending to the entire image canvas. This pull request gives the user an option to crop each layer to its real size, using PIL's crop method. The option is on by default.
-Also fixed a crash with files containing only one layer.
